### PR TITLE
Chore: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,4 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "Chore"
+    open-pull-requests-limit: 15


### PR DESCRIPTION
Add `open-pull-requests-limit: 15` to the `github-actions`
ecosystem entry in the dependabot configuration file.

This aligns the configuration with the `actions-template`
repository.